### PR TITLE
Updated host "rec" annotation (tool tip) to not reference Max 5 and a…

### DIFF
--- a/extras/ppooll_host.maxpat
+++ b/extras/ppooll_host.maxpat
@@ -379,7 +379,7 @@
 			}
 , 			{
 				"box" : 				{
-					"annotation" : "record a stereo file of whatever is currently audible quickly into the max5 application folder.",
+					"annotation" : "record a stereo file of whatever is currently audible quickly into the max application folder or a folder you have set in the preferences menu (i.e., prf)",
 					"bgcolor" : [ 0.74902, 0.74902, 0.74902, 0.0 ],
 					"bgoncolor" : [ 0.917647, 0.12549, 0.12549, 0.0 ],
 					"fontface" : 1,


### PR DESCRIPTION
…lso explain to the user where the default recording folder can be set (prf)